### PR TITLE
Add hashsums.txt to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,6 +217,12 @@ jobs:
     - name: Download all workflow run artifacts
       uses: actions/download-artifact@v3
 
+    - name: Compute hashsums and create hashsums.txt
+      run: |
+        (cd vmlinux && sha256sum *) > hashsums.txt
+        (cd kernel-image && sha256sum *) >> hashsums.txt
+        (cd rootfs && sha256sum *) >> hashsums.txt
+
     - run: ls -lR
 
     - name: Set output variables
@@ -235,3 +241,4 @@ jobs:
           vmlinux/*
           kernel-image/*
           rootfs/*
+          hashsums.txt


### PR DESCRIPTION
This PR adds a hashsums.txt to the CI.

The file can then be used to verify the image integrity but can also help other projects, e.g. `pwndbg` to improve their CI by caching the images and only (re)downloading them if either the cache is empty or the hashsums have changed.