### PR TITLE
feat: allow lvl5 paging

### DIFF
--- a/config/config.fragment
+++ b/config/config.fragment
@@ -89,3 +89,6 @@ CONFIG_TRACING=y
 # Mount tracefs at /sys/kernel/debug/tracing in addition to /sys/kernel/tracing.
 # Some tools still require the older debugfs path
 # CONFIG_TRACEFS_DISABLE_AUTOMOUNT is not set
+
+# Allow lvl5 paging
+CONFIG_X86_5LEVEL=y


### PR DESCRIPTION
This PR allows for lvl5 paging on x86_64 if the hardware or qemu support it and if it is not disabled via the kernel cmdline.