### PR TITLE
Rewrite Github workflows and create linux headers debpkg release

### DIFF
--- a/.github/actions/build-kernel/action.yml
+++ b/.github/actions/build-kernel/action.yml
@@ -31,6 +31,7 @@ runs:
           build-essential \
           bc \
           bison \
+          debhelper \
           flex \
           libelf-dev \
           libssl-dev \
@@ -81,3 +82,11 @@ runs:
         ARCH: ${{ inputs.arch }}
       run: |
         make -j$(nproc) linux
+
+    - name: Build debpkg
+      shell: bash
+      env:
+        ACK: ${{ inputs.ack }}
+        ARCH: ${{ inputs.arch }}
+      run: |
+        make -j$(nproc) linux_bindebpkg

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -31,6 +31,7 @@ jobs:
     with:
       host-os: ubuntu-22.04
       arch: ${{ matrix.arch }}
+      use-cached: true
 
   build-and-test:
     uses: ./.github/workflows/build-and-test.yml

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -1,0 +1,46 @@
+name: Build and Test All
+on:
+  push:
+    branches:
+      - main
+    path:
+      - '*'
+      - '!**/*.md'
+  pull_request:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    strategy:
+      matrix:
+        kernel: [{ack: 0, version: 5.10.y}, {ack: 0, version: 5.15.y}, {ack: 0, version: 6.1.y}, {ack: 0, version: 6.6.y}, {ack: 1, version: android13-5.10-lts}, {ack: 1, version: android14-5.15-lts}]
+        arch: [arm64, x86_64]
+    with:
+      host-os: ubuntu-20.04
+      ack: ${{ matrix.kernel.ack }}
+      arch: ${{ matrix.arch }}
+      version: ${{ matrix.kernel.version }}
+
+  rootfs:
+    uses: ./.github/workflows/rootfs.yml
+    strategy:
+      matrix:
+        arch: [arm64, x86_64]
+    with:
+      host-os: ubuntu-22.04
+      arch: ${{ matrix.arch }}
+
+  build-and-test:
+    uses: ./.github/workflows/build-and-test.yml
+    needs: rootfs
+    strategy:
+      matrix:
+        kernel: [{ack: 0, version: 5.10.y}, {ack: 0, version: 5.15.y}, {ack: 0, version: 6.1.y}, {ack: 0, version: 6.6.y}, {ack: 1, version: android13-5.10-lts}, {ack: 1, version: android14-5.15-lts}]
+        arch: [arm64, x86_64]
+    with:
+      host-os: ubuntu-22.04
+      ack: ${{ matrix.kernel.ack }}
+      arch: ${{ matrix.arch }}
+      version: ${{ matrix.kernel.version }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,61 @@
+name: Build And Test
+on:
+  workflow_dispatch:
+    inputs:
+      host-os:
+        required: false
+        type: choice
+        options:
+          - ubuntu-22.04
+          - ubuntu-20.04
+        default: ubuntu-22.04
+      ack:
+        required: true
+        type: choice
+        options:
+          - '0'
+          - '1'
+      arch:
+        required: true
+        type: choice
+        options:
+          - x86_64
+          - arm64
+      version:
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      host-os:
+        required: false
+        type: string
+        default: ubuntu-22.04
+      ack:
+        required: true
+        type: string
+      arch:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      host-os: ${{ inputs.host-os }}
+      ack: ${{ inputs.ack }}
+      arch: ${{ inputs.arch }}
+      version: ${{ inputs.version }}
+
+  test:
+    uses: ./.github/workflows/test.yml
+    needs: build
+    with:
+      ack: ${{ inputs.ack }}
+      arch: ${{ inputs.arch }}
+      version: ${{ inputs.version }}
+      artifact-dir: ${{ needs.build.outputs.artifact-dir }}
+      kernel-image-name: ${{ needs.build.outputs.kernel-image-name }}
+      suffix: ${{ needs.build.outputs.suffix }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,6 +24,10 @@ on:
       version:
         required: true
         type: string
+      use-cached:
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       host-os:
@@ -39,6 +43,10 @@ on:
       version:
         required: true
         type: string
+      use-cached:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -48,6 +56,7 @@ jobs:
       ack: ${{ inputs.ack }}
       arch: ${{ inputs.arch }}
       version: ${{ inputs.version }}
+      use-cached: ${{ inputs.use-cached }}
 
   test:
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ on:
       version:
         required: true
         type: string
-      cache:
+      use-cached:
         required: false
         type: boolean
         default: false
@@ -42,7 +42,7 @@ on:
       version:
         required: true
         type: string
-      cache:
+      use-cached:
         required: false
         type: boolean
         default: false
@@ -133,8 +133,8 @@ jobs:
 
         echo "ARTIFACT_DIR=kernel-artifacts-${SUFFIX}" >> $GITHUB_OUTPUT
 
-    # TODO: Control caching with an input argument
     - name: Cache kernel image
+      if: ${{ inputs.use-cached == true }}
       id: cache-kernel
       uses: actions/cache@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,31 +1,107 @@
 name: Build
-on: [workflow_dispatch]
+on:
+  workflow_dispatch:
+    inputs:
+      host-os:
+        required: true
+        type: choice
+        options:
+          - ubuntu-22.04
+          - ubuntu-20.04
+      ack:
+        required: true
+        type: choice
+        options:
+          - "0"
+          - "1"
+      arch:
+        required: true
+        type: choice
+        options:
+          - x86_64
+          - arm64
+      version:
+        required: true
+        type: string
+      cache:
+        required: false
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      host-os:
+        required: false
+        type: string
+        default: ubuntu-22.04
+      ack:
+        required: true
+        type: string
+      arch:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      cache:
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      artifact-dir:
+        value: ${{ jobs.build.outputs.artifact-dir }}
+      kernel-image-name:
+        value: ${{ jobs.build.outputs.kernel-image-name }}
+      suffix:
+        value: ${{ jobs.build.outputs.suffix }}
+      version:
+        value: ${{ jobs.build.outputs.version }}
 
 jobs:
   build:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
-        kernel: [{ack: 0, version: 5.10.y}, {ack: 0, version: 5.15.y}, {ack: 0, version: 6.1.y}, {ack: 0, version: 6.6.y}, {ack: 1, version: android13-5.10-lts}, {ack: 1, version: android14-5.15-lts}]
-        arch: [arm64, x86_64]
-    runs-on: ${{ matrix.os }}
+    name: Build (ack=${{ inputs.ack }}, ${{ inputs.version }}, ${{ inputs.arch }}, ${{ inputs.host-os }})
+    runs-on: ${{ inputs.host-os }}
     timeout-minutes: 100
     env:
-      ACK: ${{ matrix.kernel.ack }}
-      ARCH: ${{ matrix.arch }}
+      ACK: ${{ inputs.ack }}
+      ARCH: ${{ inputs.arch }}
     outputs:
-      SHORT_HASH: ${{ steps.vars.outputs.SHORT_HASH }}
+      artifact-dir: ${{ steps.vars.outputs.ARTIFACT_DIR }}
+      kernel-image-name: ${{ steps.vars.outputs.KERNEL_IMAGE_NAME }}
+      suffix: ${{ steps.vars.outputs.SUFFIX }}
+      version: ${{ steps.version.outputs.VERSION }}
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+
+    - name: Get real kernel version
+      id: version
+      shell: bash
+      run: |
+        LINUX_URL=https://cdn.kernel.org/pub/linux/kernel
+        VERSION="${{ inputs.version }}"
+        first_char=${VERSION:0:1}
+        last_char=${VERSION: -1:1}
+        if [ $last_char == y ]; then
+          major_minor=${VERSION: 0:-1}
+
+          # We do this in multiple steps instead of a chain of pipes to make debugging easier
+          TMP=$(curl -s $LINUX_URL/v${first_char}.x/)
+          TMP=$(echo "$TMP" | sed -e 's/<[^>]*>//g')
+          TMP=$(echo "$TMP" | grep -oP "linux-${major_minor}[0-9]+")
+          TMP=$(echo "$TMP" | sort -r -V)
+          TMP=$(echo "$TMP" | head -n1)
+          TMP=$(echo "$TMP" | cut -d '-' -f2)
+
+          VERSION=$TMP
+        fi
+
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
     - name: Set output variables
       id: vars
+      shell: bash
       run: |
         set -x
-
-        SHORT_HASH=$(git rev-parse --short HEAD)
 
         if [ $ACK -eq 0 ]; then
           KERNEL_TYPE=linux
@@ -38,41 +114,35 @@ jobs:
         if [ $ARCH == x86_64 ]; then
           # We need to use the real image in the x86 folder because caching
           # doesn't work with symlinks
-          KERNEL_IMAGE="${OUT_DIR}/arch/x86/boot/bzImage"
+          KERNEL_IMAGE="arch/x86/boot/bzImage"
         elif [ $ARCH == arm64 ]; then
-          KERNEL_IMAGE="${OUT_DIR}/arch/${ARCH}/boot/Image"
+          KERNEL_IMAGE="arch/arm64/boot/Image"
         fi
 
-        echo "SHORT_HASH=$SHORT_HASH" >> $GITHUB_OUTPUT
+        SUFFIX=${KERNEL_TYPE}-${{ steps.version.outputs.VERSION }}-${{ inputs.arch }}
+
+        echo "SUFFIX=$SUFFIX" >> $GITHUB_OUTPUT
         echo "OUT_DIR=$OUT_DIR" >> $GITHUB_OUTPUT
         echo "KERNEL_TYPE=$KERNEL_TYPE" >> $GITHUB_OUTPUT
         echo "KERNEL_IMAGE=$KERNEL_IMAGE" >> $GITHUB_OUTPUT
+        echo "KERNEL_IMAGE_NAME=$(basename $KERNEL_IMAGE)" >> $GITHUB_OUTPUT
 
-    - name: Get real kernel version
-      run: |
-        LINUX_URL=https://cdn.kernel.org/pub/linux/kernel
-        VERSION="${{ matrix.kernel.version }}"
-        first_char=${VERSION:0:1}
-        last_char=${VERSION: -1:1}
-        if [ $last_char == y ]; then
-          major_minor=${VERSION: 0:-1}
-          VERSION=$(curl -s $LINUX_URL/v${first_char}.x/ \
-            | sed -e 's/<[^>]*>//g' \
-            | grep -oP "linux-${major_minor}[0-9]+" \
-            | sort -r -V \
-            | head -n1 \
-            | cut -d '-' -f2)
-        fi
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "FINAL_KERNEL_IMAGE_PATH=${OUT_DIR}/$(basename ${KERNEL_IMAGE})-${SUFFIX}" >> $GITHUB_OUTPUT
+        echo "FINAL_VMLINUX_PATH=${OUT_DIR}/vmlinux-${SUFFIX}" >> $GITHUB_OUTPUT
+        echo "FINAL_LINUX_HEADERS_PATH=${OUT_DIR}/linux-headers-${SUFFIX}.deb" >> $GITHUB_OUTPUT
 
+        echo "ARTIFACT_DIR=kernel-artifacts-${SUFFIX}" >> $GITHUB_OUTPUT
+
+    # TODO: Control caching with an input argument
     - name: Cache kernel image
       id: cache-kernel
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
-        key: ${{ matrix.os }}-${{ env.VERSION }}-${{ matrix.arch }}
+        key: ${{ inputs.host-os }}-${{ steps.vars.outputs.SUFFIX }}
         path: |
-          ${{ steps.vars.outputs.KERNEL_IMAGE }}
-          ${{ steps.vars.outputs.OUT_DIR }}/vmlinux
+          ${{ steps.vars.outputs.FINAL_KERNEL_IMAGE_PATH }}
+          ${{ steps.vars.outputs.FINAL_VMLINUX_PATH }}
+          ${{ steps.vars.outputs.FINAL_LINUX_HEADERS_PATH }}
 
     - run: ls -lR
       if: ${{ steps.cache-kernel.outputs.cache-hit == 'true' }}
@@ -81,164 +151,24 @@ jobs:
       if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
       uses: ./.github/actions/build-kernel
       with:
-        os: ${{ matrix.os }}
-        arch: ${{ matrix.arch }}
-        ack: ${{ matrix.kernel.ack }}
-        kernel-version: ${{ env.VERSION }}
+        os: ${{ inputs.host-os }}
+        arch: ${{ inputs.arch }}
+        ack: ${{ inputs.ack }}
+        kernel-version: ${{ steps.version.outputs.VERSION }}
 
     - name: Rename kernel images
+      if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
       run: |
-        SUFFIX=${{ steps.vars.outputs.KERNEL_TYPE }}-${{ env.VERSION }}-${{ matrix.arch }}
-        cp ${{ steps.vars.outputs.KERNEL_IMAGE }} ${{ steps.vars.outputs.KERNEL_IMAGE }}-$SUFFIX
-        cp ${{ steps.vars.outputs.OUT_DIR }}/vmlinux ${{ steps.vars.outputs.OUT_DIR }}/vmlinux-$SUFFIX
-
-        echo "SUFFIX=$SUFFIX" >> $GITHUB_ENV
+        mv ${{ steps.vars.outputs.OUT_DIR }}/${{ steps.vars.outputs.KERNEL_IMAGE }} ${{ steps.vars.outputs.FINAL_KERNEL_IMAGE_PATH }}
+        mv ${{ steps.vars.outputs.OUT_DIR }}/vmlinux ${{ steps.vars.outputs.FINAL_VMLINUX_PATH }}
+        mv ${{ steps.vars.outputs.OUT_DIR }}/../linux-headers-*.deb ${{ steps.vars.outputs.FINAL_LINUX_HEADERS_PATH }}
 
     - name: Upload kernel image artifact
-      if: ${{ matrix.os == 'ubuntu-22.04' }}
-      uses: actions/upload-artifact@v3
+      if: ${{ inputs.host-os == 'ubuntu-22.04' }}
+      uses: actions/upload-artifact@v4
       with:
-        name: kernel-image
-        path: ${{ steps.vars.outputs.KERNEL_IMAGE }}-${{ env.SUFFIX }}
-
-    - name: Upload vmlinux artifact
-      if: ${{ matrix.os == 'ubuntu-22.04' }}
-      uses: actions/upload-artifact@v3
-      with:
-        name: vmlinux
-        path: ${{ steps.vars.outputs.OUT_DIR }}/vmlinux-${{ env.SUFFIX }}
-
-  run:
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        kernel: [{ack: 0, version: 5.10.y}, {ack: 0, version: 5.15.y}, {ack: 0, version: 6.1.y}, {ack: 1, version: android13-5.10-lts}]
-        arch: [arm64, x86_64]
-    timeout-minutes: 20
-    runs-on: ubuntu-22.04
-    env:
-      ACK: ${{ matrix.kernel.ack }}
-      ARCH: ${{ matrix.arch }}
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Download all workflow run artifacts
-      uses: actions/download-artifact@v3
-
-    - name: Install common dependencies
-      shell: bash
-      run: sudo apt update && sudo apt install -y debootstrap
-
-    - name: Install x86_64 dependencies
-      if: ${{ matrix.arch == 'x86_64' }}
-      shell: bash
-      run: sudo apt install -y qemu-system-x86
-
-    - name: Install arm64 dependencies
-      if: ${{ matrix.arch == 'arm64' }}
-      shell: bash
-      run: sudo apt install -y qemu-system-arm qemu-user-static binfmt-support
-
-    - name: Get real kernel version
-      run: |
-        LINUX_URL=https://cdn.kernel.org/pub/linux/kernel
-        VERSION="${{ matrix.kernel.version }}"
-        first_char=${VERSION:0:1}
-        last_char=${VERSION: -1:1}
-        if [ $last_char == y ]; then
-          major_minor=${VERSION: 0:-1}
-          VERSION=$(curl -s $LINUX_URL/v${first_char}.x/ \
-            | sed -e 's/<[^>]*>//g' \
-            | grep -oP "linux-${major_minor}[0-9]+" \
-            | sort -r -V \
-            | head -n1 \
-            | cut -d '-' -f2)
-        fi
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
-
-    - name: Set output variables
-      id: vars
-      run: |
-        set -x
-
-        if [ $ACK -eq 0 ]; then
-          KERNEL_TYPE=linux
-        else
-          KERNEL_TYPE=ack
-        fi
-
-        SUFFIX=$KERNEL_TYPE-${{ env.VERSION }}-${{ matrix.arch }}
-
-        if [ $ARCH == x86_64 ]; then
-          IMAGE_NAME=bzImage-$SUFFIX
-        else
-          IMAGE_NAME=Image-$SUFFIX
-        fi
-
-        echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
-
-    - name: Initialize rootfs and initramfs
-      run: |
-        set -x
-        make rootfs-init
-        ROOTFS=./alpine-${{ matrix.arch }}.img make rootfs-init
-
-        scripts/ubuntu_debootstrap.sh jammy ${{ matrix.arch }}
-        SUDO=1 ROOTFS_DIR=./rootfs/ubuntu-jammy-${{ matrix.arch }} CPIO_FILE=ubuntu-jammy-${{ matrix.arch }}.cpio.gz make rootfs-overlay
-
-    - name: Setup shared/init.sh
-      run: |
-        mkdir shared
-        echo poweroff > shared/init.sh
-        chmod +x shared/init.sh
-
-    - name: Run kernel
-      run: |
-        QEMU_KERNEL_IMAGE=./kernel-image/$IMAGE_NAME make run
-        QEMU_KERNEL_IMAGE=./kernel-image/$IMAGE_NAME ROOTFS=./rootfs/ubuntu-jammy-${{ matrix.arch }}.img make run
-        QEMU_KERNEL_IMAGE=./kernel-image/$IMAGE_NAME INITRD=1 make run
-        QEMU_KERNEL_IMAGE=./kernel-image/$IMAGE_NAME INITRD=./ubuntu-jammy-${{ matrix.arch }}.cpio.gz make run
-        QEMU_KERNEL_IMAGE=./kernel-image/$IMAGE_NAME CPU=2 MEM=2048M QEMU_EXTRA_ARGS="" QEMU_EXTRA_KERNEL_CMDLINE="nokaslr" ROOTFS=./alpine-${{ matrix.arch }}.img make run
-
-    - name: Upload rootfs artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: rootfs
-        path: rootfs/alpine-${{ matrix.arch }}.img
-
-  release:
-    runs-on: ubuntu-22.04
-    needs: [run, build]
-    permissions:
-      contents: write
-    steps:
-
-    - name: Download all workflow run artifacts
-      uses: actions/download-artifact@v3
-
-    - name: Compute hashsums and create hashsums.txt
-      run: |
-        (cd vmlinux && sha256sum *) > hashsums.txt
-        (cd kernel-image && sha256sum *) >> hashsums.txt
-        (cd rootfs && sha256sum *) >> hashsums.txt
-
-    - run: ls -lR
-
-    - name: Set output variables
-      id: vars
-      run: |
-        set -x
-
-        echo "DATE=$(date +'%Y.%m.%d')" >> $GITHUB_OUTPUT
-
-    - name: Publish release
-      uses: softprops/action-gh-release@v1
-      with:
-        prerelease: true
-        tag_name: ${{ steps.vars.outputs.DATE }}-${{ needs.build.outputs.SHORT_HASH }}
-        files: |
-          vmlinux/*
-          kernel-image/*
-          rootfs/*
-          hashsums.txt
+        name: ${{ steps.vars.outputs.ARTIFACT_DIR }}
+        path: |
+          ${{ steps.vars.outputs.FINAL_KERNEL_IMAGE_PATH }}
+          ${{ steps.vars.outputs.FINAL_VMLINUX_PATH }}
+          ${{ steps.vars.outputs.FINAL_LINUX_HEADERS_PATH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+on: [workflow_dispatch]
+
+jobs:
+  build-and-test-all:
+    uses: ./.github/workflows/build-and-test-all.yml
+
+  release:
+    runs-on: ubuntu-22.04
+    needs: [build-and-test-all]
+    permissions:
+      contents: write
+    steps:
+
+    - name: Download kernel artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: kernel-artifacts-*
+        merge-multiple: true
+        path: kernel-artifacts
+
+    - name: Download rootfs artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: rootfs-*
+        merge-multiple: true
+        path: rootfs
+
+    - run: ls -lR
+
+    - name: Compute hashsums and create hashsums.txt
+      shell: bash
+      run: |
+        shopt -s extglob
+        (cd kernel-artifacts && sha256sum !(*.deb)) > hashsums.txt
+        (cd rootfs && sha256sum *) >> hashsums.txt
+
+    - name: Set output variables
+      id: vars
+      run: |
+        set -x
+
+        SHORT_HASH=${GITHUB_SHA:0:7}
+        DATE=$(date +'%Y.%m.%d')
+
+        echo "SUFFIX=${DATE}-${SHORT_HASH}" >> $GITHUB_OUTPUT
+
+    - name: Publish release
+      uses: softprops/action-gh-release@v2
+      with:
+        prerelease: true
+        tag_name: ${{ steps.vars.outputs.SUFFIX }}
+        files: |
+          kernel-artifacts/vmlinux*
+          kernel-artifacts/Image*
+          kernel-artifacts/bzImage*
+          rootfs/*
+          hashsums.txt
+
+    - name: Publish header release
+      uses: softprops/action-gh-release@v2
+      with:
+        prerelease: true
+        tag_name: linux-headers-${{ steps.vars.outputs.SUFFIX }}
+        files: kernel-artifacts/linux-headers-*.deb

--- a/.github/workflows/rootfs.yml
+++ b/.github/workflows/rootfs.yml
@@ -1,0 +1,129 @@
+name: Build Rootfs
+on:
+  workflow_dispatch:
+    inputs:
+      host-os:
+        required: false
+        type: string
+        default: ubuntu-22.04
+      arch:
+        required: true
+        type: choice
+        options:
+          - x86_64
+          - arm64
+      cache:
+        required: false
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      host-os:
+        required: false
+        type: string
+        default: ubuntu-22.04
+      arch:
+        required: true
+        type: string
+      # TODO: Actually use this
+      cache:
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  check-cache:
+    name: Check cache (${{ inputs.arch }})
+    runs-on: ${{ inputs.host-os }}
+    outputs:
+      cache-hit: ${{ steps.cache-check.outputs.cache-hit }}
+    env:
+      ALPINE_ROOTFS: alpine-${{ inputs.arch }}.img
+      ALPINE_CPIO: alpine-${{ inputs.arch }}.cpio.gz
+      UBUNTU_ROOTFS: ubuntu-jammy-${{ inputs.arch }}.img
+      UBUNTU_CPIO: ubuntu-jammy-${{ inputs.arch }}.cpio.gz
+    steps:
+
+      - name: Restore cache for rootfs
+        id: cache-check
+        uses: actions/cache/restore@v4
+        with:
+          key: rootfs-${{ inputs.arch }}
+          path: |
+            rootfs/${{ env.ALPINE_ROOTFS }}
+            rootfs/${{ env.UBUNTU_ROOTFS }}
+            rootfs/${{ env.ALPINE_CPIO }}
+            rootfs/${{ env.UBUNTU_CPIO }}
+
+      - name: Upload rootfs artifact
+        if: steps.cache-check.outputs.cache-hit == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rootfs-${{ inputs.arch }}
+          path: |
+            rootfs/${{ env.ALPINE_ROOTFS }}
+            rootfs/${{ env.UBUNTU_ROOTFS }}
+            rootfs/${{ env.ALPINE_CPIO }}
+            rootfs/${{ env.UBUNTU_CPIO }}
+
+  rootfs:
+    name: rootfs (${{ inputs.arch }})
+    needs: check-cache
+    if: needs.check-cache.outputs.cache-hit != 'true'
+    runs-on: ${{ inputs.host-os }}
+    env:
+      # ARCH isn't directly used by the workflow, but it is used by the `make` commands
+      ARCH: ${{ inputs.arch }}
+      ALPINE_ROOTFS: alpine-${{ inputs.arch }}.img
+      ALPINE_CPIO: alpine-${{ inputs.arch }}.cpio.gz
+      UBUNTU_ROOTFS: ubuntu-jammy-${{ inputs.arch }}.img
+      UBUNTU_CPIO: ubuntu-jammy-${{ inputs.arch }}.cpio.gz
+    steps:
+
+    - uses: actions/checkout@v4
+
+    - name: Install common dependencies
+      run: sudo apt update && sudo apt install -y debootstrap qemu-utils
+
+    - name: Install arm64 dependencies
+      if: ${{ inputs.arch == 'arm64' }}
+      run: sudo apt install -y qemu-user-static binfmt-support
+
+    - name: Initialize rootfs and initramfs
+      shell: bash
+      run: |
+        set -x
+
+        make rootfs-init
+
+        # Test generating rootfs in non-standard location
+        ROOTFS=${ALPINE_ROOTFS} make rootfs-init
+
+        # Verify it matches previously generated rootfs
+        cmp ./${ALPINE_ROOTFS} ./rootfs/${ALPINE_ROOTFS}
+
+        # Generate ubuntu rootfs and cpio (with CPIO at a non-standard location)
+        scripts/ubuntu_debootstrap.sh jammy ${{ inputs.arch }}
+        SUDO=1 ROOTFS_DIR=./rootfs/ubuntu-jammy-${{ inputs.arch }} CPIO_FILE=${UBUNTU_CPIO} make rootfs-overlay
+
+        mv ./${UBUNTU_CPIO} rootfs/${UBUNTU_CPIO}
+
+    - name: Cache rootfs artifacts
+      uses: actions/cache/save@v4
+      with:
+        key: rootfs-${{ inputs.arch }}
+        path: |
+          rootfs/${{ env.ALPINE_ROOTFS }}
+          rootfs/${{ env.UBUNTU_ROOTFS }}
+          rootfs/${{ env.ALPINE_CPIO }}
+          rootfs/${{ env.UBUNTU_CPIO }}
+
+    - name: Upload rootfs artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: rootfs-${{ inputs.arch }}
+        path: |
+          rootfs/${{ env.ALPINE_ROOTFS }}
+          rootfs/${{ env.UBUNTU_ROOTFS }}
+          rootfs/${{ env.ALPINE_CPIO }}
+          rootfs/${{ env.UBUNTU_CPIO }}

--- a/.github/workflows/rootfs.yml
+++ b/.github/workflows/rootfs.yml
@@ -12,7 +12,7 @@ on:
         options:
           - x86_64
           - arm64
-      cache:
+      use-cached:
         required: false
         type: boolean
         default: false
@@ -25,8 +25,7 @@ on:
       arch:
         required: true
         type: string
-      # TODO: Actually use this
-      cache:
+      use-cached:
         required: false
         type: boolean
         default: true
@@ -45,6 +44,7 @@ jobs:
     steps:
 
       - name: Restore cache for rootfs
+        if: ${{ inputs.use-cached == true }}
         id: cache-check
         uses: actions/cache/restore@v4
         with:
@@ -98,9 +98,6 @@ jobs:
 
         # Test generating rootfs in non-standard location
         ROOTFS=${ALPINE_ROOTFS} make rootfs-init
-
-        # Verify it matches previously generated rootfs
-        cmp ./${ALPINE_ROOTFS} ./rootfs/${ALPINE_ROOTFS}
 
         # Generate ubuntu rootfs and cpio (with CPIO at a non-standard location)
         scripts/ubuntu_debootstrap.sh jammy ${{ inputs.arch }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,91 @@
+name: Test
+on:
+  workflow_call:
+    inputs:
+      host-os:
+        required: false
+        type: string
+        default: ubuntu-22.04
+      ack:
+        required: true
+        type: string
+      arch:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      artifact-dir:
+        required: true
+        type: string
+      kernel-image-name:
+        required: true
+        type: string
+      suffix:
+        required: true
+        type: string
+      
+jobs:
+  test:
+    name: Test (ack=${{ inputs.ack }}, ${{ inputs.version }}, ${{ inputs.arch }})
+    runs-on: ubuntu-22.04
+    # Put ACK and ARCH in the environment so it's picked up by the `make` commands
+    env:
+      ACK: ${{ inputs.ack }}
+      ARCH: ${{ inputs.arch }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Download kernel artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.artifact-dir }}
+        path: ${{ inputs.artifact-dir }}
+
+    - name: Download rootfs artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: rootfs-${{ inputs.arch }}
+        path: rootfs
+
+    - run: ls -lR
+
+    - name: Install x86_64 dependencies
+      if: ${{ inputs.arch == 'x86_64' }}
+      run: sudo apt update && sudo apt install -y qemu-system-x86
+
+    - name: Install arm64 dependencies
+      if: ${{ inputs.arch == 'arm64' }}
+      run: sudo apt update && sudo apt install -y qemu-system-arm
+
+    - name: Setup shared/init.sh
+      run: |
+        mkdir shared
+        echo poweroff > shared/init.sh
+        chmod +x shared/init.sh
+
+    - name: Run kernel
+      run: |
+        export QEMU_KERNEL_IMAGE=${{ inputs.artifact-dir }}/${{ inputs.kernel-image-name }}-${{ inputs.suffix }}
+        
+        ALPINE_ROOTFS=alpine-${{ inputs.arch }}.img
+        UBUNTU_ROOTFS=ubuntu-jammy-${{ inputs.arch }}.img
+        UBUNTU_CPIO=ubuntu-jammy-${{ inputs.arch }}.cpio.gz
+        
+        cp ./rootfs/${ALPINE_ROOTFS} ./${ALPINE_ROOTFS}
+        cp ./rootfs/${UBUNTU_CPIO} ./${UBUNTU_CPIO}
+
+        # Run with default alpine rootfs
+        make run
+
+        # Run with ubuntu rootfs
+        ROOTFS=./rootfs/${UBUNTU_ROOTFS} make run
+
+        # Run with default alpine cpio
+        INITRD=1 make run
+
+        # Run with ubuntu cpio in non-standard location
+        INITRD=./${UBUNTU_CPIO} make run
+
+        # Run with alpine rootfs in non-standard location, with additional options
+        CPU=2 MEM=2048M QEMU_EXTRA_ARGS="" QEMU_EXTRA_KERNEL_CMDLINE="nokaslr" ROOTFS=./${ALPINE_ROOTFS} make run

--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,10 @@ linux_modules $(LINUX_OUT_MODULES_DEP): $(KERNEL_IMAGE)
 	@cmp $(LINUX_OUT_MODULES_DEP).tmp $(LINUX_OUT_MODULES_DEP) || \
 		mv $(LINUX_OUT_MODULES_DEP).tmp $(LINUX_OUT_MODULES_DEP)
 
+.PHONY: linux_bindebpkg
+linux_bindebpkg: $(KERNEL_IMAGE)
+	+ $(LINUX_MAKE) bindeb-pkg
+
 .PHONY: linux_clean
 linux_clean:
 	+ $(LINUX_MAKE) mrproper


### PR DESCRIPTION
Switched to using reusable workflows. Also generate a linux-headers debpkg release, which can be used to build out-of-tree kernel modules without building the entire kernel.